### PR TITLE
epd7in5のdummyを作成。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ stg.env
 prod.env
 
 table.json
+
+epd_image.png

--- a/epd7in5_dummy.py
+++ b/epd7in5_dummy.py
@@ -37,22 +37,10 @@ class EPD:
 
     def getbuffer(self, image):
         img = image
-        imwidth, imheight = img.size
-        if(imwidth == self.width and imheight == self.height):
-            img = img.convert('1')
-        elif(imwidth == self.height and imheight == self.width):
-            # image has correct dimensions, but needs to be rotated
-            img = img.rotate(90, expand=True).convert('1')
-        else:
-            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
-            # return a blank buffer
-            return [0x00] * (int(self.width/8) * self.height)
-
-        buf = bytearray(img.tobytes('raw'))
-        # The bytes need to be inverted, because in the PIL world 0=black and 1=white, but
-        # in the e-paper world 0=white and 1=black.
-        for i in range(len(buf)):
-            buf[i] ^= 0xFF
+        # 画像ファイルを保存する
+        img.save("epd_image.png")
+        # dummyではbufは使わない
+        buf = bytearray()
         return buf
 
     def display(self, image):

--- a/epd7in5_dummy.py
+++ b/epd7in5_dummy.py
@@ -1,0 +1,68 @@
+import logging
+
+# Display resolution
+EPD_WIDTH       = 800
+EPD_HEIGHT      = 480
+
+logger = logging.getLogger(__name__)
+
+class EPD:
+    """
+    epd7in5 Dummy class.
+    """
+    def __init__(self):
+        self.width = EPD_WIDTH
+        self.height = EPD_HEIGHT
+
+    def reset(self):
+        pass
+
+    def send_command(self, command):
+        pass
+
+    def send_data(self, data):
+        pass
+
+    def send_data2(self, data):
+        pass
+
+    def ReadBusy(self):
+        pass
+        
+    def SetLut(self, lut_vcom, lut_ww, lut_bw, lut_wb, lut_bb):
+        pass
+
+    def init(self):
+        return 0
+
+    def getbuffer(self, image):
+        img = image
+        imwidth, imheight = img.size
+        if(imwidth == self.width and imheight == self.height):
+            img = img.convert('1')
+        elif(imwidth == self.height and imheight == self.width):
+            # image has correct dimensions, but needs to be rotated
+            img = img.rotate(90, expand=True).convert('1')
+        else:
+            logger.warning("Wrong image dimensions: must be " + str(self.width) + "x" + str(self.height))
+            # return a blank buffer
+            return [0x00] * (int(self.width/8) * self.height)
+
+        buf = bytearray(img.tobytes('raw'))
+        # The bytes need to be inverted, because in the PIL world 0=black and 1=white, but
+        # in the e-paper world 0=white and 1=black.
+        for i in range(len(buf)):
+            buf[i] ^= 0xFF
+        return buf
+
+    def display(self, image):
+        pass
+
+    def Clear(self):
+        pass
+
+    def sleep(self):
+        pass
+
+### END OF FILE ###
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,6 @@
-anyio==3.6.2
-click==8.1.3
-fastapi==0.88.0
-h11==0.14.0
-idna==3.4
-Pillow==9.3.0
-pydantic==1.10.2
-python-dotenv==0.21.0
-RPi.GPIO==0.7.1
-sniffio==1.3.0
-spidev==3.6
-starlette==0.22.0
-typing-extensions==4.4.0
-uvicorn==0.20.0
+# 本番環境用
+-r requirements/prod.txt
+# 結合環境用
+# -r requirements/stg.txt
+# 開発環境用
+# -r requirements/dev.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,12 @@
+anyio==3.6.2
+click==8.1.3
+fastapi==0.88.0
+h11==0.14.0
+idna==3.4
+Pillow==9.3.0
+pydantic==1.10.2
+python-dotenv==0.21.0
+sniffio==1.3.0
+starlette==0.22.0
+typing-extensions==4.4.0
+uvicorn==0.20.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,3 @@
+# requirements for development
+-r common.txt
+# この下に開発環境でしか使わないパッケージを列挙する

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,5 @@
+# requirements for production
+-r common.txt
+# この下に本番環境専用のパッケージを列挙する
+RPi.GPIO==0.7.1
+spidev==3.6

--- a/requirements/stg.txt
+++ b/requirements/stg.txt
@@ -1,0 +1,3 @@
+# requirements for staging
+-r common.txt
+# この下に結合環境でしか使わないパッケージを列挙する


### PR DESCRIPTION
Windows,macOSの場合はdummyを呼び出すように修正。
フォントとフォントサイズをSettingsに追加して、Settingsの値を参照するように修正
とりあえず外側だけ。ウィンドウに表示等はこれから。

表示内容を、画像ファイルに出力できるようにしました。
![epd_image](https://user-images.githubusercontent.com/54230974/206669996-c6610696-f21a-4aca-b15f-a640a6c396b5.png)
