### PR TITLE
電子ペーパー表示内容をウィンドウに表示する機能を追加

### DIFF
--- a/epd7in5_dummy.py
+++ b/epd7in5_dummy.py
@@ -1,10 +1,10 @@
-import logging
+import subprocess
 
 # Display resolution
 EPD_WIDTH       = 800
 EPD_HEIGHT      = 480
 
-logger = logging.getLogger(__name__)
+EPD_IMAGE_PATH = 'epd_image.png'
 
 class EPD:
     """
@@ -13,6 +13,15 @@ class EPD:
     def __init__(self):
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
+        # windowプロセスを起動する
+        self.winProc = subprocess.Popen(
+            ['python', 'epd7in5_window.py']
+            )
+
+    def __del__(self):
+        # windowプロセスを終了させる
+        if self.winProc.poll:
+            self.winProc.kill()
 
     def reset(self):
         pass
@@ -38,7 +47,7 @@ class EPD:
     def getbuffer(self, image):
         img = image
         # 画像ファイルを保存する
-        img.save("epd_image.png")
+        img.save(EPD_IMAGE_PATH)
         # dummyではbufは使わない
         buf = bytearray()
         return buf

--- a/epd7in5_window.py
+++ b/epd7in5_window.py
@@ -1,0 +1,39 @@
+import sys
+import os
+from PyQt6.QtWidgets import QApplication, QWidget, QLabel
+from PyQt6.QtCore import QTimer
+from PyQt6.QtGui import QPixmap
+
+EPD_IMAGE_PATH = 'epd_image.png'
+
+# Display resolution
+EPD_WIDTH       = 800
+EPD_HEIGHT      = 480
+
+class EpdWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('epd7in5')      # ウィンドウのタイトル
+        self.setGeometry(100, 100, EPD_WIDTH + 20, EPD_HEIGHT + 20)   # ウィンドウの位置と大きさ
+        # ラベルの設定
+        self.label = QLabel(self)
+        self.label.move(10, 10)                             # ラベルの位置
+        self.label.setFixedSize(EPD_WIDTH, EPD_HEIGHT)      # ラベルのサイズ指定
+        # *ラベルのサイズをあらかじめ指定しておかないと、画像ファイルの表示がうまくいかない
+        # タイマーの設定
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._run)
+        self.timer.start(1000)  # 1秒間隔
+    # タイマー
+    def _run(self):
+        # 画像ファイルが存在する場合
+        if os.path.isfile(EPD_IMAGE_PATH):
+            # 画像ファイル読み込み
+            pix = QPixmap(EPD_IMAGE_PATH)
+            # 画像ファイルをラベルに設定
+            self.label.setPixmap(pix)
+
+qAp = QApplication(sys.argv)
+epdwindow = EpdWindow()
+epdwindow.show()
+qAp.exec()

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,6 @@
 # requirements for development
 -r common.txt
 # この下に開発環境でしか使わないパッケージを列挙する
+PyQt6==6.4.0
+PyQt6-Qt6==6.4.1
+PyQt6-sip==13.4.0


### PR DESCRIPTION
PyQtを使用して、ウィンドウを作成。
epd7in5_dummy.pyから、subprocessを使用して起動。
タイマーを使用して、1秒毎に画像ファイルが存在する場合、ウィンドウに表示。
<img width="932" alt="スクリーンショット 2022-12-10 14 52 08" src="https://user-images.githubusercontent.com/54230974/206831857-ff436dce-df24-490f-9a32-e165290e1373.png">
